### PR TITLE
Moved to smbus2

### DIFF
--- a/custom_components/waveshare_ups_hat/ina219.py
+++ b/custom_components/waveshare_ups_hat/ina219.py
@@ -1,6 +1,6 @@
 
 # https://github.com/waveshare/UPS-Power-Module/blob/master/ups_display/ina219.py
-import smbus
+import smbus2 as smbus
 import time
 
 # Config Register (R/W)

--- a/custom_components/waveshare_ups_hat/manifest.json
+++ b/custom_components/waveshare_ups_hat/manifest.json
@@ -3,7 +3,7 @@
   "name": "Waveshare UPS Hat",
   "documentation": "https://github.com/mykhailog/hacs_waveshare_ups_hat",
   "issue_tracker": "https://github.com/mykhailog/hacs_waveshare_ups_hat/issues",
-  "requirements": ["smbus-cffi==0.5.1"],
+  "requirements": ["smbus2>=0.4.2"],
   "codeowners": ["@mykhailog"],
-  "version": "0.1.3"
+  "version": "0.1.4"
 }


### PR DESCRIPTION
### History
On July 7, 2022, HA Core update 2022.7.1 was introduced that was based on Python 3.10. However,it seems that  `smbus-cffi`, the library that is being used by the current integration to communicate with INA219 over I2C, does not support Python 3.10 since the last update for the library was in April 2017. Due to this, the current integration was broken in HA leading to sensors being unavailable to the users.

### Resolution
The most logical solution was to use `smbus2` library that is said to be a drop-in replacement for `smbus-cffi` with minor changes. 

### PR
This PR is based on changes by @icaruseffect on his [fork](https://github.com/icaruseffect/hacs_waveshare_ups_hat) that seems to work so all credits to him. Making this PR so that when accepted, those who are already using your custom integration would get an update on on their HACS and repair their broken integration.