### PR TITLE
SMA filtering, batteries count

### DIFF
--- a/custom_components/waveshare_ups_hat/ina219_wrapper.py
+++ b/custom_components/waveshare_ups_hat/ina219_wrapper.py
@@ -1,0 +1,58 @@
+import numpy as np
+from collections import deque
+from .ina219 import INA219
+
+COEF_SMAx2 = 2
+
+class INA219Wrapper:
+    def __init__(self, ina219 : INA219, samples_cnt : int):
+        self._ina219 = ina219
+        self._bus_voltage_buf = deque(maxlen=samples_cnt * COEF_SMAx2)
+        self._shunt_voltage_buf = deque(maxlen=samples_cnt)
+        self._current_buf = deque(maxlen=samples_cnt * COEF_SMAx2)
+        self._power_buf = deque(maxlen=samples_cnt)
+        self._attrs = {}
+
+    def measureINAValues(self):
+        self._current_buf.append(self._ina219.getCurrent_mA())
+        self._bus_voltage_buf.append(self._ina219.getBusVoltage_V())
+        self._shunt_voltage_buf.append(self._ina219.getShuntVoltage_mV())
+        self._power_buf.append(self._ina219.getPower_W())
+
+    def getCurrentSMA_mA(self):
+        return self._getSMAValue(self._current_buf)
+
+    def getBusVoltageSMA_V(self):
+        return self._getSMAValue(self._bus_voltage_buf)
+
+    def getShuntVoltageSMA_mV(self):
+        return self._getSMAValue(self._shunt_voltage_buf)
+
+    def getPowerSMA_W(self):
+        return self._getSMAValue(self._power_buf)
+
+    def getCurrentSMAx2_mA(self):
+        return self._getSMAValue(self._current_buf, COEF_SMAx2)
+
+    def getBusVoltageSMAx2_V(self):
+        return self._getSMAValue(self._bus_voltage_buf, COEF_SMAx2)
+
+    def isBusVoltageBufFilled(self):
+        if len(self._bus_voltage_buf) == self._bus_voltage_buf.maxlen:
+            return True
+        return False
+
+    def _getSMAValue(self, buf:deque, divider:int=1):
+        if divider > 1:
+            return np.mean(self._getBufTail(buf, divider))
+        return np.mean(buf)
+
+    def _getSMMValue(self, buf:deque, divider:int=1):
+        if divider > 1:
+            return np.median(self._getBufTail(buf, divider))
+        return np.median(buf)
+
+    def _getBufTail(self, buf:deque, divider:int):
+        slice_start = len(buf) - int(len(buf) / divider)
+        slice_end = len(buf)
+        return list(buf)[slice_start:slice_end]

--- a/custom_components/waveshare_ups_hat/manifest.json
+++ b/custom_components/waveshare_ups_hat/manifest.json
@@ -3,7 +3,7 @@
   "name": "Waveshare UPS Hat",
   "documentation": "https://github.com/mykhailog/hacs_waveshare_ups_hat",
   "issue_tracker": "https://github.com/mykhailog/hacs_waveshare_ups_hat/issues",
-  "requirements": ["smbus2>=0.4.2"],
+  "requirements": ["smbus2>=0.4.2","numpy>=1.23.2"],
   "codeowners": ["@mykhailog"],
-  "version": "0.1.6"
+  "version": "0.1.7"
 }

--- a/custom_components/waveshare_ups_hat/sensor.py
+++ b/custom_components/waveshare_ups_hat/sensor.py
@@ -4,19 +4,25 @@ import os
 
 import voluptuous as vol
 
-from homeassistant.components.sensor import SensorEntity,PLATFORM_SCHEMA
-from homeassistant.const import DEVICE_CLASS_BATTERY, PERCENTAGE, CONF_NAME, CONF_UNIQUE_ID
+from homeassistant.components.sensor import SensorEntity, PLATFORM_SCHEMA
+from homeassistant.const import (
+    DEVICE_CLASS_BATTERY,
+    PERCENTAGE,
+    CONF_NAME,
+    CONF_UNIQUE_ID,
+)
 import homeassistant.helpers.config_validation as cv
 
 
 _LOGGER = logging.getLogger(__name__)
 
 from .ina219 import INA219
+from .ina219_wrapper import INA219Wrapper
 from .const import (
     MIN_CHARGING_CURRENT,
     MIN_ONLINE_CURRENT,
     MIN_BATTERY_CONNECTED_CURRENT,
-    LOW_BATTERY_PERCENTAGE
+    LOW_BATTERY_PERCENTAGE,
 )
 
 ATTR_CAPACITY = "capacity"
@@ -31,21 +37,28 @@ ATTR_CHARGING = "charging"
 ATTR_ONLINE = "online"
 ATTR_BATTERY_CONNECTED = "battery_connected"
 ATTR_LOW_BATTERY = "low_battery"
-ATTR_POWER_CALCULATED= "power_calculated"
+ATTR_POWER_CALCULATED = "power_calculated"
 
 ATTR_REMAINING_BATTERY_CAPACITY = "remaining_battery_capacity"
 ATTR_REMAINING_TIME = "remaining_time_min"
 
-CONF_BATTERY_CAPACITY= "battery_capacity"
-CONF_MAX_SOC = 'max_soc'
+CONF_BATTERY_CAPACITY = "battery_capacity"
+CONF_MAX_SOC = "max_soc"
+CONF_SMA_SAMPLES = "sma_samples"
+CONF_BATTERIES_COUNT = "batteries_count"
 DEFAULT_NAME = "waveshare_ups_hat"
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_MAX_SOC, default=100): cv.positive_int,
-    vol.Optional(CONF_BATTERY_CAPACITY): cv.positive_int,
-    vol.Optional(CONF_UNIQUE_ID): cv.string,
-})
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_MAX_SOC, default=100): cv.positive_int,
+        vol.Optional(CONF_BATTERY_CAPACITY): cv.positive_int,
+        vol.Optional(CONF_BATTERIES_COUNT, default=2): cv.positive_int,
+        vol.Optional(CONF_SMA_SAMPLES, default=5): cv.positive_int,
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
+    }
+)
+
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Waveshare UPS Hat sensor."""
@@ -53,23 +66,27 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     unique_id = config.get(CONF_UNIQUE_ID)
     max_soc = config.get(CONF_MAX_SOC)
     battery_capacity = config.get(CONF_BATTERY_CAPACITY)
-    add_entities([WaveshareUpsHat(name,unique_id,max_soc,battery_capacity)], True)
+    batteries_count = config.get(CONF_BATTERIES_COUNT)
+    sma_samples = config.get(CONF_SMA_SAMPLES)
+    add_entities([WaveshareUpsHat(name, unique_id, max_soc, battery_capacity, batteries_count, sma_samples)], True)
 
 
 class WaveshareUpsHat(SensorEntity):
     """Representation of a Waveshare UPS Hat."""
 
-    def __init__(self, name, unique_id=None, max_soc=None, battery_capacity=None):
+    def __init__(self, name, unique_id=None, max_soc=None, battery_capacity=None, batteries_count=None, sma_samples=None):
         """Initialize the sensor."""
         self._name = name
         self._unique_id = unique_id
         if max_soc > 100:
-           max_soc = 100
+            max_soc = 100
         elif max_soc < 1:
-           max_soc = 1
+            max_soc = 1
         self._max_soc = max_soc
         self._battery_capacity = battery_capacity
-        self._ina219 = INA219(addr=0x42)
+        self._batteries_count = batteries_count
+        self._ina219 = INA219(addr=0x41)
+        self._ina219_wrapper = INA219Wrapper(self._ina219, sma_samples)
         self._attrs = {}
 
     @property
@@ -104,29 +121,33 @@ class WaveshareUpsHat(SensorEntity):
 
     def update(self):
         """Get the latest data and updates the states."""
-        ina219 = self._ina219
-        bus_voltage = ina219.getBusVoltage_V()  # voltage on V- (load side)
-        shunt_voltage = (
-            ina219.getShuntVoltage_mV() / 1000
-        )  # voltage between V+ and V- across the shunt
-        current = ina219.getCurrent_mA()  # current in mA
-        power = ina219.getPower_W()  # power in W
+        ina219_wrapper = self._ina219_wrapper
+        ina219_wrapper.measureINAValues()
 
-        real_soc = (bus_voltage - 6) / 2.4 * 100
+        bus_voltage = ina219_wrapper.getBusVoltageSMA_V()  # voltage on V- (load side)
+        shunt_voltage = (ina219_wrapper.getShuntVoltageSMA_mV() / 1000)  # voltage between V+ and V- across the shunt
+        current = ina219_wrapper.getCurrentSMA_mA()  # current in mA
+        power = ina219_wrapper.getPowerSMA_W()  # power in W
 
-        soc  = (bus_voltage - 6) / (2.4 * (self._max_soc / 100.0) )  * 100
+        smooth_bus_voltage = ina219_wrapper.getBusVoltageSMAx2_V()
+        smooth_current = ina219_wrapper.getCurrentSMAx2_mA()
+
+        soc_c1 = 3 * self._batteries_count
+        soc_c2 = 1.2 * self._batteries_count
+        real_soc = (smooth_bus_voltage - soc_c1) / soc_c2 * 100
+        soc = (smooth_bus_voltage - soc_c1) / (soc_c2 * (self._max_soc / 100.0)) * 100
 
         if soc > 100:
             soc = 100
         if soc < 0:
             soc = 0
 
-        #battery_connected = current > MIN_BATTERY_CONNECTED_CURRENT
+        # battery_connected = current > MIN_BATTERY_CONNECTED_CURRENT
 
-        online = current > MIN_ONLINE_CURRENT
-        charging = current > MIN_CHARGING_CURRENT
+        online = bool(current > MIN_ONLINE_CURRENT)
+        charging = bool(current > MIN_CHARGING_CURRENT)
 
-        low_battery = online and soc < LOW_BATTERY_PERCENTAGE
+        low_battery = bool(online and (soc < LOW_BATTERY_PERCENTAGE))
         power_calculated = bus_voltage * (current / 1000)
 
         if self._battery_capacity is None:
@@ -134,10 +155,10 @@ class WaveshareUpsHat(SensorEntity):
             remaining_time = None
         else:
             remaining_battery_capacity = (real_soc / 100.0) * self._battery_capacity
-            if current < 0:
-                remaining_time = round((remaining_battery_capacity / -current) * 60.0, 0)
-            elif current > 0:
-                remaining_time = None # round(((self._battery_capacity - remaining_battery_capacity) / current) * 60.0, 0)
+            if not online:
+                remaining_time = round(
+                    (remaining_battery_capacity / -smooth_current) * 60.0, 0
+                )
             else:
                 remaining_time = None
 
@@ -148,16 +169,16 @@ class WaveshareUpsHat(SensorEntity):
             ATTR_CAPACITY: round(soc, 0),
             ATTR_SOC: round(soc, 0),
             ATTR_REAL_SOC: real_soc,
-            ATTR_PSU_VOLTAGE: round(bus_voltage + shunt_voltage,5),
-            ATTR_LOAD_VOLTAGE: round(bus_voltage,5),
-            ATTR_SHUNT_VOLTAGE: round(shunt_voltage,5),
-            ATTR_CURRENT: round(current,5),
-            ATTR_POWER: round(power,5),
-            ATTR_POWER_CALCULATED: round(power_calculated,5),
+            ATTR_PSU_VOLTAGE: round(bus_voltage + shunt_voltage, 5),
+            ATTR_LOAD_VOLTAGE: round(bus_voltage, 5),
+            ATTR_SHUNT_VOLTAGE: round(shunt_voltage, 5),
+            ATTR_CURRENT: round(current / 1000, 5),
+            ATTR_POWER: round(power, 5),
+            ATTR_POWER_CALCULATED: round(power_calculated, 5),
             ATTR_CHARGING: charging,
             ATTR_ONLINE: online,
             ATTR_REMAINING_BATTERY_CAPACITY: remaining_battery_capacity,
             ATTR_REMAINING_TIME: remaining_time,
-#            ATTR_BATTERY_CONNECTED: battery_connected,
-            ATTR_LOW_BATTERY: low_battery
+            #            ATTR_BATTERY_CONNECTED: battery_connected,
+            ATTR_LOW_BATTERY: low_battery,
         }

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,9 @@ sensor:
   - platform: waveshare_ups_hat
     name: UPS                    # Optional
     unique_id: waveshare_ups     # Optional
+    max_soc: 91                  # Optional
+    sma_samples: 5               # Optional
+    batteries_count: 2           # Optional
 ```
 Following data can be read:
  - SoC (State of Charge)
@@ -68,6 +71,9 @@ sensor:
 ```
 
 *Tip:* Doubled window size is used for calculation of SoC, Remaining Battery Capacity and Remaining Time
+
+#### Batteries Count
+Original Waveshare UPS Hat have 2 batteries in series (8.4V) but some versions of UPS Hat have 3 batteries (12.6V). Use `batteries_count` in case of more than 2 batteries in series on your device. 
 
 ### Binary Sensor
 In addition to the  sensor devices, you may also create a device which is simply “on” when the UPS status is online and “off” at all other times.

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,18 @@ sensor:
     max_soc: 91                      
 ```
 
+#### SMA Filtering
+By default SMA5 filter is applied to values from INA219. This is needed to filter out noise from switching power supply and provide more smooth readings. You can control window size with `sma_samples` property. 
+
+```yaml
+sensor:
+  - platform: waveshare_ups_hat
+    max_soc: 91
+    sma_samples: 10                    
+```
+
+*Tip:* Doubled window size is used for calculation of SoC, Remaining Battery Capacity and Remaining Time
+
 ### Binary Sensor
 In addition to the  sensor devices, you may also create a device which is simply “on” when the UPS status is online and “off” at all other times.
 

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ sensor:
 ```
 
 #### SMA Filtering
-By default SMA5 filter is applied to values from INA219. This is needed to filter out noise from switching power supply and provide more smooth readings. You can control window size with `sma_samples` property. 
+By default, the SMA5 filter is applied to the measurements from INA219. That's necessary to filter out noise from the switching power supply and provide smoother readings. You can control the window size with the `sma_samples` property.
 
 ```yaml
 sensor:
@@ -73,7 +73,7 @@ sensor:
 *Tip:* Doubled window size is used for calculation of SoC, Remaining Battery Capacity and Remaining Time
 
 #### Batteries Count
-Original Waveshare UPS Hat have 2 batteries in series (8.4V) but some versions of UPS Hat have 3 batteries (12.6V). Use `batteries_count` in case of more than 2 batteries in series on your device. 
+The original Waveshare UPS Hat has 2 batteries in series (8.4V), but some versions of the UPS Hat may have 3 batteries (12.6V). If you have more than 2 batteries in series, use the `batteries_count` parameter.
 
 ### Binary Sensor
 In addition to the  sensor devices, you may also create a device which is simply “on” when the UPS status is online and “off” at all other times.


### PR DESCRIPTION
- Simple moving average is applied for INA219 measurements by default with window size 5. Could be changed with `sma_samples` param
-  `batteries_count` parameter for 12.6V UPS Hat versions with 3 batteries in series. Used in SoC calculations
- Doubled window size is used for calculation of SoC, Remaining Battery Capacity and Remaining Time to provide even more smoothing

- Filtering of the INA219 measurements implemented in wrapper class
- Due to sensor readings count and memory optimisations, actual measurement and storing values to buffers moved to separate method. It may be additionally sampled if needed (for example on every HA update read INA219 data 5 times with 100ms intervals and count additional mean on every single value)